### PR TITLE
Remove doubling of size

### DIFF
--- a/cs-algorithms/UnionFind/WeightedQuickUnionWithPathCompression.cs
+++ b/cs-algorithms/UnionFind/WeightedQuickUnionWithPathCompression.cs
@@ -40,16 +40,19 @@ namespace Algorithms.UnionFind
         {
             int i = GetRoot(p);
             int j = GetRoot(q);
-            if (mSize[i] < mSize[j])
+            if (i!=j)
             {
-                mParent[i] = j;
-                mSize[j] += mSize[i];
-            }
-            else
-            {
-                mParent[j] = i;
-                mSize[i] += mSize[j];
-            }
+                if (mSize[i] < mSize[j])
+                {
+                    mParent[i] = j;
+                    mSize[j] += mSize[i];
+                }
+                else
+                {
+                    mParent[j] = i;
+                    mSize[i] += mSize[j];
+                }
+            }         
         }
 
         public bool IsConnected(int i, int j)


### PR DESCRIPTION
Added check so already connected values does not double the size. Currently, if the root of the two numbers we want to add to the union are already connected, the size gets double. Checking for isConnected is also an option, but this is a faster approach.